### PR TITLE
Link d'acquisto con icona nelle schede libro

### DIFF
--- a/src/components/icons/IconCart.astro
+++ b/src/components/icons/IconCart.astro
@@ -1,0 +1,9 @@
+---
+import IconBase from "./IconBase.astro";
+---
+
+<IconBase {...Astro.props}>
+  <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"></path>
+  <path d="M3 6h18"></path>
+  <path d="M16 10a4 4 0 0 1-8 0"></path>
+</IconBase>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -64,6 +64,10 @@ const books = defineCollection({
       city: z.string().optional(),
       // Set only for works that won a literary award (per the biography).
       award: z.string().optional(),
+      // Storefront where the book can still be bought. Rendered as an
+      // icon + link next to the other metadata; the label shows the shop's
+      // hostname, so no separate vendor name is needed.
+      purchaseUrl: z.string().url().optional(),
       // Mixed granularity in the source data (YYYY / YYYY-MM / YYYY-MM-DD),
       // kept as a string and sorted lexically (ISO-ordered).
       date: z.string(),

--- a/src/content/books/it/storiografia/salvemini-dannunzio-pascoli-prezzolini.md
+++ b/src/content/books/it/storiografia/salvemini-dannunzio-pascoli-prezzolini.md
@@ -6,6 +6,7 @@ date: "2019"
 category: "storiografia"
 slug: "salvemini-dannunzio-pascoli-prezzolini"
 image: "./covers/salvemini-dannunzio-pascoli-prezzolini.jpg"
+purchaseUrl: "https://edizionihelicon.it/libri/salvemini-d-annunzio-pascoli-prezzolini-c"
 ---
 > «Vicende e personaggi. Artisti e intellettuali. Cultura e politica. Il
 > saggio di Marco Ignazio de Santis è una analisi matura e ben condotta

--- a/src/content/books/it/storiografia/w-salvemini.md
+++ b/src/content/books/it/storiografia/w-salvemini.md
@@ -6,7 +6,5 @@ date: "2013"
 category: "storiografia"
 slug: "w-salvemini"
 image: "./covers/w-salvemini.jpg"
+purchaseUrl: "https://www.libreriauniversitaria.it/salvemini-elezioni-politiche-1913-collegi/libro/9788854859654"
 ---
-
-[Acquista il libro su
-libreriauniversitaria.it](https://www.libreriauniversitaria.it/salvemini-elezioni-politiche-1913-collegi/libro/9788854859654)

--- a/src/i18n/dictionaries/it.ts
+++ b/src/i18n/dictionaries/it.ts
@@ -53,6 +53,7 @@ export const it = {
     "book.eyebrow": "Opera",
     "book.coverAlt": 'Copertina di "{title}"',
     "book.enlargeCover": "Ingrandisci la copertina",
+    "book.purchase": "Acquista su {vendor}",
 
     // SEO
     "seo.shortDescription": "Poeta, scrittore e giornalista",

--- a/src/pages/opere/[category]/[book].astro
+++ b/src/pages/opere/[category]/[book].astro
@@ -16,6 +16,7 @@ import {
 import { defaultLocale, isLocale } from "@/i18n/locales";
 import { bookDisplayTitle, bookImageAlt } from "@utils/books";
 import IconAward from "@components/icons/IconAward.astro";
+import IconCart from "@components/icons/IconCart.astro";
 
 export async function getStaticPaths() {
   const books = await getCollection(
@@ -65,6 +66,12 @@ const bookSchema = {
 };
 
 const lightboxId = `book-cover-${book.data.slug}`;
+
+// Label for the purchase link: the storefront's bare hostname
+// ("edizionihelicon.it"), which reads better than a full URL.
+const purchaseVendor = book.data.purchaseUrl
+  ? new URL(book.data.purchaseUrl).hostname.replace(/^www\./, "")
+  : undefined;
 ---
 
 <BaseLayout
@@ -139,6 +146,21 @@ const lightboxId = `book-cover-${book.data.slug}`;
                   {book.data.award}
                 </p>
               </div>
+            )
+          }
+          {
+            book.data.purchaseUrl && (
+              <a
+                href={book.data.purchaseUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="group mt-4 inline-flex items-center gap-2 text-primary transition-colors hover:text-terracotta-light"
+              >
+                <IconCart class="h-4 w-4 shrink-0" strokeWidth={1.5} />
+                <span class="font-body text-sm uppercase tracking-widest group-hover:underline underline-offset-4">
+                  {tl("book.purchase", { vendor: purchaseVendor! })}
+                </span>
+              </a>
             )
           }
           <Divider class="my-8 mx-0!" />


### PR DESCRIPTION
## Cosa

I link agli store vivevano nel corpo markdown come normale link di prosa. Ora sono un campo di frontmatter `purchaseUrl`, reso accanto agli altri metadati come riga icona + link, nello stesso stile della riga premio: icona carrello, etichetta terracotta in maiuscoletto spaziato, sottolineatura in hover, apertura in nuova scheda.

L'etichetta mostra l'hostname del negozio ricavato dall'URL (`edizionihelicon.it`), quindi non serve un campo separato per il nome del venditore.

## Contenuti aggiornati

- **Salvemini - d'Annunzio - Pascoli - Prezzolini & C.** — nuovo link alla pagina Edizioni Helicon.
- **W Salvemini** — link libreriauniversitaria.it spostato dal corpo al frontmatter (il corpo resta vuoto, come per altre schede).

Entrambi gli URL rispondono 200.

## Verifica

- `astro check`: 0 errori
- `eslint`: pulito
- Entrambe le pagine controllate nel preview locale, nessun errore in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)